### PR TITLE
CFE-3781: Deleted extra cruft from the masterfiles build

### DIFF
--- a/index.json
+++ b/index.json
@@ -92,8 +92,14 @@
       "tags": ["official", "base"],
       "repo": "https://github.com/cfengine/masterfiles",
       "by": "https://github.com/cfengine",
-      "commit": "c39b79c0e7a42522c69cff3d87a5bc5ac9471369",
-      "steps": ["run ./autogen.sh", "delete ./autogen.sh", "copy ./ ./"]
+      "commit": "3ce8f9ed53fdcb3b41013d6fadc284b6d46aea53",
+      "steps": [
+          "run ./autogen.sh",
+          "delete ./autogen.sh",
+          "run ./cfbs/cleanup.sh",
+          "delete ./cfbs/cleanup.sh",
+          "copy ./ ./"
+        ]
     },
     "migrate2rocky": {
         "description": "Unattended migration of CentOS 8 hosts to Rocky Linux",


### PR DESCRIPTION
Merge together:
https://github.com/cfengine/masterfiles/pull/2107


Before:
```
❯ ls -a out/masterfiles
.               templates            configure         MPF.md
..              tests                configure.ac      promises.cf
autom4te.cache  travis-scripts       CONTRIBUTING.md   promises.cf.in
cfe_internal    aclocal.m4           example_def.json  README.md
controls        .CFVERSION           .gitignore        standalone_self_upgrade.cf
.git            CFVERSION            install-sh        standalone_self_upgrade.cf.in
inventory       CHANGELOG.md         LICENSE           test-driver
lib             CODE_OF_CONDUCT.org  .mailmap          .travis.yml
m4              config.guess         Makefile          update.cf
misc            config.log           Makefile.am
modules         config.status        Makefile.in
services        config.sub           missing
```

After:
```
❯ ls -a out/masterfiles
.   cfe_internal  inventory  modules   templates    standalone_self_upgrade.cf
..  controls      lib        services  promises.cf  update.cf
```